### PR TITLE
Minor compile fixes

### DIFF
--- a/source/f16_to_f128M.c
+++ b/source/f16_to_f128M.c
@@ -63,7 +63,6 @@ void f16_to_f128M( float16_t a, float128_t *zPtr )
     struct commonNaN commonNaN;
     uint32_t uiZ96;
     struct exp8_sig16 normExpSig;
-    uint64_t frac64;
 
     /*------------------------------------------------------------------------
     *------------------------------------------------------------------------*/

--- a/source/s_shiftRightJamM.c
+++ b/source/s_shiftRightJamM.c
@@ -88,10 +88,10 @@ void
         }
         ptr = zPtr + indexMultiwordHi( size_words, wordDist );
     }
-    do {
+    while ( wordDist ) {
         *ptr++ = 0;
         --wordDist;
-    } while ( wordDist );
+    };
  wordJam:
     if ( wordJam ) zPtr[indexWordLo( size_words )] |= 1;
 


### PR DESCRIPTION
These fixes came up while investigating upgrading QEMU's SoftFloat from 2a to 3c:

  https://lists.gnu.org/archive/html/qemu-devel/2017-07/msg06583.html

If this is indeed the best way to get fixes upstream we would we would be keen for the QEMU/SoftFloat interaction to be less one-way ;-)