### PR TITLE
Add typedef for exception flags enumeration

### DIFF
--- a/source/include/softfloat.h
+++ b/source/include/softfloat.h
@@ -81,13 +81,13 @@ enum {
 | Software floating-point exception flags.
 *----------------------------------------------------------------------------*/
 extern THREAD_LOCAL uint_fast8_t softfloat_exceptionFlags;
-enum {
+typedef enum {
     softfloat_flag_inexact   =  1,
     softfloat_flag_underflow =  2,
     softfloat_flag_overflow  =  4,
     softfloat_flag_infinite  =  8,
     softfloat_flag_invalid   = 16
-};
+} exceptionFlag_t;
 
 /*----------------------------------------------------------------------------
 | Routine to raise any or all of the software floating-point exception flags.


### PR DESCRIPTION
This patch adds  typedef for exception flags enumeration.

In https://github.com/sequencer/arithmetic/blob/2685fb7ec6dc7cca7ee3808377d841d19a9d2ced/emulator/src/testharness.h#L32 and https://github.com/sequencer/arithmetic/blob/2685fb7ec6dc7cca7ee3808377d841d19a9d2ced/emulator/src/testharness.cc#L107  , I am trying to use softfloat and testfloat as link libraries to test my float-point unit and found it was necessary to have the enumeration type definition for  exporting the  flags data.