### PR TITLE
Fix typo in function 'softfloat_propagateNaNF128M' for ARM-VFPv2-defaultNaN

### DIFF
--- a/source/ARM-VFPv2-defaultNaN/s_propagateNaNF128M.c
+++ b/source/ARM-VFPv2-defaultNaN/s_propagateNaNF128M.c
@@ -54,7 +54,7 @@ void
 {
 
     if (
-        f128M_isSignalingNaN( (const float128_t *) aWPtr );
+        f128M_isSignalingNaN( (const float128_t *) aWPtr )
             || (bWPtr && f128M_isSignalingNaN( (const float128_t *) bWPtr ))
     ) {
         softfloat_raiseFlags( softfloat_flag_invalid );


### PR DESCRIPTION
remove extra semicolon