### PR TITLE
fix(extF80): correct add/sub for valid inputs with J-bit clear

### DIFF
--- a/source/s_addMagsExtF80.c
+++ b/source/s_addMagsExtF80.c
@@ -70,6 +70,38 @@ extFloat80_t
     expB = expExtF80UI64( uiB64 );
     sigB = uiB0;
     /*------------------------------------------------------------------------
+    | Normalize unnormals (non-zero exponent but J-bit clear), matching the
+    | guard in `extF80_mul' and `extF80_div'.
+    *------------------------------------------------------------------------*/
+    if ( expA && (expA != 0x7FFF)
+            && ! (sigA & UINT64_C( 0x8000000000000000 )) ) {
+        if ( ! sigA ) { expA = 0; }
+        else {
+            normExpSig = softfloat_normSubnormalExtF80Sig( sigA );
+            if ( expA + normExpSig.exp >= 1 ) {
+                expA += normExpSig.exp;
+                sigA = normExpSig.sig;
+            } else {
+                if ( expA > 1 ) sigA <<= (expA - 1);
+                expA = 0;
+            }
+        }
+    }
+    if ( expB && (expB != 0x7FFF)
+            && ! (sigB & UINT64_C( 0x8000000000000000 )) ) {
+        if ( ! sigB ) { expB = 0; }
+        else {
+            normExpSig = softfloat_normSubnormalExtF80Sig( sigB );
+            if ( expB + normExpSig.exp >= 1 ) {
+                expB += normExpSig.exp;
+                sigB = normExpSig.sig;
+            } else {
+                if ( expB > 1 ) sigB <<= (expB - 1);
+                expB = 0;
+            }
+        }
+    }
+    /*------------------------------------------------------------------------
     *------------------------------------------------------------------------*/
     expDiff = expA - expB;
     if ( ! expDiff ) {
@@ -78,12 +110,21 @@ extFloat80_t
                 goto propagateNaN;
             }
             uiZ64 = uiA64;
-            uiZ0  = uiA0;
+            uiZ0  = UINT64_C( 0x8000000000000000 );
             goto uiZ;
         }
         sigZ = sigA + sigB;
         sigZExtra = 0;
         if ( ! expA ) {
+            if ( sigZ < sigA ) {
+                /*------------------------------------------------------------
+                | Significand addition carried (e.g., two pseudo-denormals
+                | with J=1).  Treat as effective exp=1 and fall through to
+                | `shiftRight1', which captures the carry.
+                *------------------------------------------------------------*/
+                expZ = 1;
+                goto shiftRight1;
+            }
             normExpSig = softfloat_normSubnormalExtF80Sig( sigZ );
             expZ = normExpSig.exp + 1;
             sigZ = normExpSig.sig;
@@ -98,7 +139,7 @@ extFloat80_t
         if ( expB == 0x7FFF ) {
             if ( sigB & UINT64_C( 0x7FFFFFFFFFFFFFFF ) ) goto propagateNaN;
             uiZ64 = packToExtF80UI64( signZ, 0x7FFF );
-            uiZ0  = uiB0;
+            uiZ0  = UINT64_C( 0x8000000000000000 );
             goto uiZ;
         }
         expZ = expB;
@@ -114,7 +155,7 @@ extFloat80_t
         if ( expA == 0x7FFF ) {
             if ( sigA & UINT64_C( 0x7FFFFFFFFFFFFFFF ) ) goto propagateNaN;
             uiZ64 = uiA64;
-            uiZ0  = uiA0;
+            uiZ0  = UINT64_C( 0x8000000000000000 );
             goto uiZ;
         }
         expZ = expA;
@@ -129,6 +170,7 @@ extFloat80_t
     }
  newlyAligned:
     sigZ = sigA + sigB;
+    if ( sigZ < sigA ) goto shiftRight1;
     if ( sigZ & UINT64_C( 0x8000000000000000 ) ) goto roundAndPack;
     /*------------------------------------------------------------------------
     *------------------------------------------------------------------------*/

--- a/source/s_subMagsExtF80.c
+++ b/source/s_subMagsExtF80.c
@@ -59,6 +59,7 @@ extFloat80_t
     uint_fast64_t uiZ0;
     int_fast32_t expZ;
     uint_fast64_t sigExtra;
+    struct exp32_sig64 normExpSig;
     struct uint128 sig128, uiZ;
     union { struct extFloat80M s; extFloat80_t f; } uZ;
 
@@ -68,6 +69,38 @@ extFloat80_t
     sigA = uiA0;
     expB = expExtF80UI64( uiB64 );
     sigB = uiB0;
+    /*------------------------------------------------------------------------
+    | Normalize unnormals (non-zero exponent but J-bit clear), matching the
+    | guard in `extF80_mul' and `extF80_div'.
+    *------------------------------------------------------------------------*/
+    if ( expA && (expA != 0x7FFF)
+            && ! (sigA & UINT64_C( 0x8000000000000000 )) ) {
+        if ( ! sigA ) { expA = 0; }
+        else {
+            normExpSig = softfloat_normSubnormalExtF80Sig( sigA );
+            if ( expA + normExpSig.exp >= 1 ) {
+                expA += normExpSig.exp;
+                sigA = normExpSig.sig;
+            } else {
+                if ( expA > 1 ) sigA <<= (expA - 1);
+                expA = 0;
+            }
+        }
+    }
+    if ( expB && (expB != 0x7FFF)
+            && ! (sigB & UINT64_C( 0x8000000000000000 )) ) {
+        if ( ! sigB ) { expB = 0; }
+        else {
+            normExpSig = softfloat_normSubnormalExtF80Sig( sigB );
+            if ( expB + normExpSig.exp >= 1 ) {
+                expB += normExpSig.exp;
+                sigB = normExpSig.sig;
+            } else {
+                if ( expB > 1 ) sigB <<= (expB - 1);
+                expB = 0;
+            }
+        }
+    }
     /*------------------------------------------------------------------------
     *------------------------------------------------------------------------*/
     expDiff = expA - expB;
@@ -112,6 +145,12 @@ extFloat80_t
     sigExtra = sig128.v0;
  newlyAlignedBBigger:
     expZ = expB;
+    if ( sigA < sigB ) goto bBigger;
+    if ( sigB < sigA ) goto aBigger;
+    uiZ64 =
+        packToExtF80UI64( (softfloat_roundingMode == softfloat_round_min), 0 );
+    uiZ0 = 0;
+    goto uiZ;
  bBigger:
     signZ = ! signZ;
     sig128 = softfloat_sub128( sigB, 0, sigA, sigExtra );
@@ -122,7 +161,7 @@ extFloat80_t
     if ( expA == 0x7FFF ) {
         if ( sigA & UINT64_C( 0x7FFFFFFFFFFFFFFF ) ) goto propagateNaN;
         uiZ64 = uiA64;
-        uiZ0  = uiA0;
+        uiZ0  = UINT64_C( 0x8000000000000000 );
         goto uiZ;
     }
     if ( ! expB ) {
@@ -135,6 +174,12 @@ extFloat80_t
     sigExtra = sig128.v0;
  newlyAlignedABigger:
     expZ = expA;
+    if ( sigB < sigA ) goto aBigger;
+    if ( sigA < sigB ) goto bBigger;
+    uiZ64 =
+        packToExtF80UI64( (softfloat_roundingMode == softfloat_round_min), 0 );
+    uiZ0 = 0;
+    goto uiZ;
  aBigger:
     sig128 = softfloat_sub128( sigA, 0, sigB, sigExtra );
     /*------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The extFloat80 format stores the integer bit (J, bit 63 of the significand) explicitly. Every combination of exponent and significand is a valid encoding with a defined mathematical value. The original Intel 8087 hardware defined and correctly processed all such encodings — unnormals, pseudo-denormals, pseudo-infinities, and pseudo-NaNs — as described in Intel's US Patent 4,325,120 and in every subsequent Intel architecture manual covering the x87 FPU.

`extF80_add` and `extF80_sub` produce wrong results for valid inputs where J disagrees with what the biased exponent implies. The other arithmetic functions (`extF80_mul`, `extF80_div`) already contain normalization guards that handle these inputs correctly; add and sub are missing the same guard.

### Wrong results demonstrated

| Expression | SoftFloat returns | Correct result |
|---|---|---|
| `{exp=0x3FFF, sig=0} + itself` | `{0x4000, 0x0}` (= 2.0) | `{0x0000, 0x0}` (= 0, since sig=0) |
| `{exp=0x3FFF, sig=0x4000..0} + itself` | `{0x4001, 0x4000..0}` (= 3.0) | `{0x3FFF, 0x8000..0}` (= 1.0, since the input is 0.5) |
| `{exp=0x7FFE, sig=0x7FFF..F} + 0` | `{0x7FFF, 0x8000..0}` (+Inf) | finite (large but not infinite) |
| `{exp=0, sig=0x8000..0} + itself` | `{0x0000, 0x0}` (= 0) | `{0x0002, 0x8000..0}` (= 2^(-16381), since the input is the pseudo-denormal 2^(-16382)) |

A standalone program demonstrating all of these: https://gist.github.com/johnwbyrd/cb75a1844661677fe614bc39f171fe39

### Root causes and fixes

**s_addMagsExtF80.c:**

1. **Missing normalization guard.** `extF80_mul` and `extF80_div` normalize inputs whose J-bit is clear before performing arithmetic. `s_addMagsExtF80` does not, so it interprets the raw significand bits at the wrong magnitude. The fix adds the same guard after field extraction, with additional logic for the subnormal boundary (exp=0 and exp=1 share the same emin, so normalizing an unnormal with exp=1 must not over-shift into the normal range).

2. **Carry overflow in equal-exponent subnormal addition.** When both operands are pseudo-denormals with J=1 (e.g., `{exp=0, sig=0x8000000000000000}`), `sigA + sigB` overflows 64 bits and wraps to zero. The fix detects the carry (`sigZ < sigA`) and routes to the existing `shiftRight1` path, which recovers the carry as the new J-bit.

3. **Carry overflow at `newlyAligned`.** The same 64-bit overflow can occur after alignment when both significands have J=1 at the same effective exponent. The fix adds the same carry check.

4. **Pseudo-infinity passthrough.** Three infinity-detection paths return `uiA0` or `uiB0` as the result significand, passing through whatever bit pattern was in the input. When the input is a pseudo-infinity (`{exp=0x7FFF, sig=0}`), the output is a non-canonical infinity encoding. The fix always returns the canonical infinity significand `0x8000000000000000`.

**s_subMagsExtF80.c:**

1. Same normalization guard as addMags.

2. **Magnitude reversal at `newlyAligned{A,B}Bigger`.** When `expDiff=1` and the smaller-exponent operand is subnormal (exp=0), the code adjusts expDiff to 0 and jumps to the `newlyAligned` label, which assumes the operand with the larger exponent has the larger value. After normalization of unnormal inputs, this assumption can be false. The fix re-checks significand magnitudes at both `newlyAligned` labels.

3. Same pseudo-infinity passthrough fix (one location).

### Related

- TestFloat generator fix: ucb-bar/berkeley-testfloat-3#21
- Existing issue for carry overflow: #37
- SoftFloat mul fix (forthcoming)
- SoftFloat rem/sqrt fix (forthcoming)

## Suggested test plan

- Build SoftFloat with this patch, rebuild TestFloat with ucb-bar/berkeley-testfloat-3#21, and run `testsoftfloat -level 1 extF80_add` and `testsoftfloat -level 1 extF80_sub` — both should pass across all precisions and rounding modes
- Run `testsoftfloat -level 1 extF80_div` as a regression check (div already handles these inputs correctly and should remain clean)
- Run `testsoftfloat -level 1 f64_add` and `f32_mul` to confirm non-extF80 operations are unaffected