### PR TITLE
fix(extF80): extF80_mul returns infinity for Inf times zero

### DIFF
--- a/source/extF80_mul.c
+++ b/source/extF80_mul.c
@@ -56,7 +56,6 @@ extFloat80_t extF80_mul( extFloat80_t a, extFloat80_t b )
     int_fast32_t expB;
     uint_fast64_t sigB;
     bool signZ;
-    uint_fast64_t magBits;
     struct exp32_sig64 normExpSig;
     int_fast32_t expZ;
     struct uint128 sig128Z, uiZ;
@@ -88,13 +87,13 @@ extFloat80_t extF80_mul( extFloat80_t a, extFloat80_t b )
         ) {
             goto propagateNaN;
         }
-        magBits = expB | sigB;
-        goto infArg;
+        if ( (expB != 0x7FFF) && ! sigB ) goto invalid;
+        goto infinity;
     }
     if ( expB == 0x7FFF ) {
         if ( sigB & UINT64_C( 0x7FFFFFFFFFFFFFFF ) ) goto propagateNaN;
-        magBits = expA | sigA;
-        goto infArg;
+        if ( ! sigA ) goto invalid;
+        goto infinity;
     }
     /*------------------------------------------------------------------------
     *------------------------------------------------------------------------*/
@@ -134,15 +133,16 @@ extFloat80_t extF80_mul( extFloat80_t a, extFloat80_t b )
     goto uiZ;
     /*------------------------------------------------------------------------
     *------------------------------------------------------------------------*/
- infArg:
-    if ( ! magBits ) {
-        softfloat_raiseFlags( softfloat_flag_invalid );
-        uiZ64 = defaultNaNExtF80UI64;
-        uiZ0  = defaultNaNExtF80UI0;
-    } else {
-        uiZ64 = packToExtF80UI64( signZ, 0x7FFF );
-        uiZ0  = UINT64_C( 0x8000000000000000 );
-    }
+ invalid:
+    softfloat_raiseFlags( softfloat_flag_invalid );
+    uiZ64 = defaultNaNExtF80UI64;
+    uiZ0  = defaultNaNExtF80UI0;
+    goto uiZ;
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+ infinity:
+    uiZ64 = packToExtF80UI64( signZ, 0x7FFF );
+    uiZ0  = UINT64_C( 0x8000000000000000 );
     goto uiZ;
     /*------------------------------------------------------------------------
     *------------------------------------------------------------------------*/


### PR DESCRIPTION
## Summary

The extFloat80 format stores the integer bit (J, bit 63 of the significand) explicitly. Every combination of exponent and significand is a valid encoding with a defined mathematical value. The original Intel 8087 hardware defined and correctly processed all such encodings -- unnormals, pseudo-denormals, pseudo-infinities, and pseudo-NaNs -- as described in Intel's US Patent 4,325,120 and in every subsequent Intel architecture manual covering the x87 FPU.

When one operand is infinity, `extF80_mul` checks whether the other operand is zero (which would make the result NaN per IEEE 754) using:

```c
magBits = expB | sigB;
```

This treats any input with a non-zero exponent as non-zero, even when the significand is all zeros. An encoding like `{exp=0x0001, sig=0x0000000000000000}` has significand zero and therefore value zero, but `magBits` evaluates to non-zero because of the exponent. The function returns +Inf with no exception flags instead of NaN with the invalid flag.

### Wrong result demonstrated

| Expression | SoftFloat returns | Correct result |
|---|---|---|
| `+Inf × {exp=0x0001, sig=0}` | `{0x7FFF, 0x8000..0}` (+Inf), no flags | NaN with invalid flag (Inf × 0 is undefined) |

A standalone program demonstrating this: https://gist.github.com/johnwbyrd/cb75a1844661677fe614bc39f171fe39 (Bug 6)

### Fix

Replace the `magBits` shortcut with direct checks that correctly identify zero inputs (`sigB == 0` or `sigA == 0`) regardless of the exponent field. This matches the pattern already used in `extF80_div`, which handles these inputs correctly. The `infArg` label is split into separate `invalid` and `infinity` labels for clarity.

### Related

- TestFloat generator fix: ucb-bar/berkeley-testfloat-3#21
- SoftFloat add/sub fix: #38
- SoftFloat rem/sqrt fix (forthcoming)

## Suggested test plan

- Build SoftFloat with this patch, rebuild TestFloat with ucb-bar/berkeley-testfloat-3#21, and run `testsoftfloat -level 1 extF80_mul` -- should pass across all precisions and rounding modes
- Run `testsoftfloat -level 1 extF80_div` as a regression check (div already handles these inputs correctly)
- Run `testsoftfloat -level 1 f32_mul` to confirm non-extF80 operations are unaffected