### PR TITLE
fix(extF80): rem and sqrt mishandle pseudo-infinity inputs

### DIFF
--- a/source/extF80_rem.c
+++ b/source/extF80_rem.c
@@ -97,6 +97,7 @@ extFloat80_t extF80_rem( extFloat80_t a, extFloat80_t b )
         | that `expDiff' later is less than -1, which will result in returning
         | a canonicalized version of argument a.
         *--------------------------------------------------------------------*/
+        sigB = UINT64_C( 0x8000000000000000 );
         expB += expB;
     }
     /*------------------------------------------------------------------------

--- a/source/extF80_sqrt.c
+++ b/source/extF80_sqrt.c
@@ -78,7 +78,11 @@ extFloat80_t extF80_sqrt( extFloat80_t a )
             uiZ0  = uiZ.v0;
             goto uiZ;
         }
-        if ( ! signA ) return a;
+        if ( ! signA ) {
+            uiZ64 = packToExtF80UI64( 0, 0x7FFF );
+            uiZ0  = UINT64_C( 0x8000000000000000 );
+            goto uiZ;
+        }
         goto invalid;
     }
     /*------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The extFloat80 format stores the integer bit (J, bit 63 of the significand) explicitly. Every combination of exponent and significand is a valid encoding with a defined mathematical value. The original Intel 8087 hardware defined and correctly processed all such encodings -- unnormals, pseudo-denormals, pseudo-infinities, and pseudo-NaNs -- as described in Intel's US Patent 4,325,120 and in every subsequent Intel architecture manual covering the x87 FPU.

In extFloat80, infinity can be encoded two ways: the canonical form `{exp=0x7FFF, sig=0x8000000000000000}` with J=1, and the pseudo-infinity `{exp=0x7FFF, sig=0x0000000000000000}` with J=0. Both represent the same value (infinity).

### Wrong results demonstrated

| Expression | SoftFloat returns | Correct result |
|---|---|---|
| `rem(1.0, {exp=0x7FFF, sig=0})` | NaN with invalid flag | `1.0` with no flags (rem(finite, Inf) = finite) |
| `sqrt({exp=0x7FFF, sig=0})` | `{0x7FFF, 0x0000..0}` (non-canonical) | `{0x7FFF, 0x8000..0}` (canonical +Inf) |

A standalone program demonstrating both: https://gist.github.com/johnwbyrd/cb75a1844661677fe614bc39f171fe39 (Bugs 7 and the sqrt case)

### Root causes and fixes

**extF80_rem.c:** When the divisor B is pseudo-infinity, the infinity handler doubles `expB` (to force an early return of A unchanged), but leaves `sigB=0`. The subsequent normalization guard sees `sigB=0` and jumps to the `invalid` label, returning NaN. The fix sets `sigB` to the canonical J=1 value in the infinity handler so the normalization guard passes through. The actual value of `sigB` doesn't matter... the huge `expDiff` causes `goto copyA` before `sigB` is used in any computation.

**extF80_sqrt.c:** When the operand is pseudo-infinity, the positive-infinity path does `return a`, passing the non-canonical encoding through as the result unchanged. The fix constructs and returns the canonical infinity encoding.

### Related

- TestFloat generator fix: ucb-bar/berkeley-testfloat-3#21
- SoftFloat add/sub fix: #38
- SoftFloat mul fix: #39

## Suggested test plan

- Build SoftFloat with this patch, rebuild TestFloat with ucb-bar/berkeley-testfloat-3#21, and run `testsoftfloat -level 1 extF80_rem` and `testsoftfloat -level 1 extF80_sqrt` -- both should pass across all rounding modes
- Run `testsoftfloat -level 1 extF80_div` as a regression check
- Run `testsoftfloat -level 1 f64_add` to confirm non-extF80 operations are unaffected